### PR TITLE
Handle env files that have '=' in the value

### DIFF
--- a/shinto_cli/context.py
+++ b/shinto_cli/context.py
@@ -111,15 +111,9 @@ def _parse_env(data_string):
     """
     # Parse
     if isinstance(data_string, basestring):
-        data = filter(
-            lambda l: len(l) == 2 ,
-            (
-                list(map(
-                    str.strip,
-                    line.split('=')
-                ))
-                for line in data_string.split("\n"))
-        )
+        data = [l.split("=", 1)
+                for l in data_string.split("\n")
+                if "=" in l]
     else:
         data = data_string
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+unittest

--- a/tests/render-test.py
+++ b/tests/render-test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import unittest
 import os.path
 
@@ -12,6 +13,7 @@ class RenderTest(unittest.TestCase):
 
     #: The expected output
     expected_output = """server {
+  # foo=bar
   listen 80;
   server_name localhost;
 
@@ -67,7 +69,8 @@ class RenderTest(unittest.TestCase):
         self._testme(['--format=env', 'resources/nginx-env.j2', 'resources/data.env'])
 
         # Environment!
-        env = dict(NGINX_HOSTNAME='localhost', NGINX_WEBROOT='/var/www/project', NGINX_LOGS='/var/log/nginx/')
+        env = dict(NGINX_HOSTNAME='localhost', NGINX_WEBROOT='/var/www/project',
+                   NGINX_LOGS='/var/log/nginx/', FOOBAR="foo=bar")
         self._testme(['--format=env', 'resources/nginx-env.j2'], env=env)
         self._testme(['--format=env', 'resources/nginx-env.j2'], env=env)
 
@@ -92,3 +95,6 @@ class RenderTest(unittest.TestCase):
                 self.assertEqual(self.expected_output, result)
             else:
                 self.assertEqual(self.expected_output.encode('UTF-8'), result)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/resources/data.env
+++ b/tests/resources/data.env
@@ -1,3 +1,4 @@
 NGINX_HOSTNAME=localhost
 NGINX_WEBROOT=/var/www/project
 NGINX_LOGS=/var/log/nginx/
+FOOBAR=foo=bar

--- a/tests/resources/data.ini
+++ b/tests/resources/data.ini
@@ -2,3 +2,4 @@
 hostname=localhost
 webroot=/var/www/project
 logs=/var/log/nginx/
+foobar=foo=bar

--- a/tests/resources/data.json
+++ b/tests/resources/data.json
@@ -2,6 +2,7 @@
     "nginx":{
         "hostname": "localhost",
         "webroot": "/var/www/project",
-        "logs": "/var/log/nginx/"
+        "logs": "/var/log/nginx/",
+        "foobar": "foo=bar"
     }
 }

--- a/tests/resources/data.yaml
+++ b/tests/resources/data.yaml
@@ -2,3 +2,4 @@ nginx:
   hostname: localhost
   webroot: /var/www/project
   logs: /var/log/nginx/
+  foobar: foo=bar

--- a/tests/resources/data.yml
+++ b/tests/resources/data.yml
@@ -2,3 +2,4 @@ nginx:
   hostname: localhost
   webroot: /var/www/project
   logs: /var/log/nginx/
+  foobar: foo=bar

--- a/tests/resources/nginx-env.j2
+++ b/tests/resources/nginx-env.j2
@@ -1,4 +1,5 @@
 server {
+  # {{ FOOBAR }}
   listen 80;
   server_name {{ NGINX_HOSTNAME }};
 

--- a/tests/resources/nginx-env2.j2
+++ b/tests/resources/nginx-env2.j2
@@ -1,4 +1,5 @@
 server {
+  # {{ FOOBAR }}
   listen 80;
   server_name {{ NGINX_HOSTNAME }};
 

--- a/tests/resources/nginx.j2
+++ b/tests/resources/nginx.j2
@@ -1,4 +1,5 @@
 server {
+  # {{ nginx.foobar }}
   listen 80;
   server_name {{ nginx.hostname }};
 


### PR DESCRIPTION
Previously, if there was a line like foobar=foo=bar in an env file,
j2 would just ignore that line, but if you set a shell variable and
output the env to a file, it would be represented that way, so it
should be supported by j2 as well.